### PR TITLE
MainVisualの修正

### DIFF
--- a/src/app/home/main-visual/main-visual.component.html
+++ b/src/app/home/main-visual/main-visual.component.html
@@ -17,7 +17,7 @@
             <a href="https://drive.google.com/open?id=1LHbd2iDNuqlBhiYUKTWD6z2o8omPg984Mb6CFPu3lVQ" target="_blank" class="main-visual__action a-button is-xl is-danger is-block">Become A Speaker</a>
           </li>
           <li class="main-visual__actions-item">
-            <a href="" target="_blank" class="main-visual__action a-button is-xl is-warning is-block">Register Now</a>
+            <a href="" target="_blank" class="main-visual__action a-button is-xl is-warning is-block">Comming Soon</a>
           </li>
         </ul><!-- .main-visual__actions-items -->
       </div><!-- .main-visual__actions -->

--- a/src/app/home/main-visual/main-visual.component.html
+++ b/src/app/home/main-visual/main-visual.component.html
@@ -17,7 +17,7 @@
             <a href="https://drive.google.com/open?id=1LHbd2iDNuqlBhiYUKTWD6z2o8omPg984Mb6CFPu3lVQ" target="_blank" class="main-visual__action a-button is-xl is-danger is-block">Become A Speaker</a>
           </li>
           <li class="main-visual__actions-item">
-            <a href="" target="_blank" class="main-visual__action a-button is-xl is-warning is-block">Comming Soon</a>
+            <a href="" target="_blank" class="main-visual__action a-button is-xl is-warning is-block">Registration will start soon</a>
           </li>
         </ul><!-- .main-visual__actions-items -->
       </div><!-- .main-visual__actions -->

--- a/src/app/home/main-visual/main-visual.component.html
+++ b/src/app/home/main-visual/main-visual.component.html
@@ -12,7 +12,7 @@
       <div class="main-visual__actions">
         <ul class="main-visual__actions-items">
           <li class="main-visual__actions-item">
-            <a href="" target="_blank" class="main-visual__action a-button is-xl is-danger is-block">Become A Speaker</a>
+            <a href="https://drive.google.com/open?id=1LHbd2iDNuqlBhiYUKTWD6z2o8omPg984Mb6CFPu3lVQ" target="_blank" class="main-visual__action a-button is-xl is-danger is-block">Become A Speaker</a>
           </li>
           <li class="main-visual__actions-item">
             <a href="" target="_blank" class="main-visual__action a-button is-xl is-warning is-block">Register Now</a>

--- a/src/app/home/main-visual/main-visual.component.html
+++ b/src/app/home/main-visual/main-visual.component.html
@@ -7,7 +7,9 @@
       <div class="main-visual__text-container">
         <h1 class="main-visual__title">Tama RubyKaigi 2019</h1>
         <div class="main-visual__time">2019/07/06 (Sat) 13:00 - 18:20 </div>
-        <div class="main-visual__place">@Shibuya, Tokyo</div>
+        <div class="main-visual__place">@Shibuya, Tokyo
+          <a href="https://goo.gl/maps/9e8L4nPDKGXEuKQF7" target="_blank" class="a-text-link">(Map)</a>
+        </div>
       </div><!-- .main-visual__text-container -->
       <div class="main-visual__actions">
         <ul class="main-visual__actions-items">

--- a/src/assets/stylesheets/blocks/_main-visual.sass
+++ b/src/assets/stylesheets/blocks/_main-visual.sass
@@ -73,6 +73,9 @@ $red: #eb6e73
   +media-breakpoint-down(sm)
     font-size: 1rem
     margin-top: .25rem
+  a
+    +text-block(1.5rem 1.4 .5rem)
+    text-decoration: none
 
 .main-visual__actions
   margin-top: 2rem


### PR DESCRIPTION
### 変更内容
- `Become A Speaker`にリンク設定
  - https://drive.google.com/open?id=1LHbd2iDNuqlBhiYUKTWD6z2o8omPg984Mb6CFPu3lVQ
- `＠Shibuya, Tokyo` の後にGoogle Map追加
  - https://goo.gl/maps/9e8L4nPDKGXEuKQF7
- `Register Now` ボタンを `Comming Soon` に修正

### イメージ
<img width="980" alt="スクリーンショット 2019-04-24 12 56 25" src="https://user-images.githubusercontent.com/10830974/56631472-64901a00-6690-11e9-832a-78b4cad2eef3.png">

### 確認観点
- リンク先の妥当性
